### PR TITLE
Fix "exports" and "types" bug in `package.json`. Add watch option for build and test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Then make the following changes:
 
 - in `package.json`:
   - update all the `@briangershon` to your account name
-  - replace `npm-package-minimal` with the name of your repo. The `name` field is particularly important since this is needed for publishing your module.
-  - reset your `version` to an initial value such as `0.0.1` or `1.0.0`.
+  - replace `npm-package-minimal` with the name of your repo. The `name` field is particularly important since this is needed for publishing your module. Name should have the format `@your-github-username/your-repo-name`.
+  - reset your `version` to an initial value `0.0.0`. Note: You'll update this version when publishing package.
 - update `LICENSE` file with your own name or license.
 - update `README.md` with your own content.
 - optional update `.prettierrc.json` or `eslint.config.js` with your own settings.
@@ -43,6 +43,24 @@ In your project, install this package like so:
 
 ```bash
 npm install @briangershon/npm-package-minimal
+```
+
+## Run tests while developing this package
+
+```bash
+npm run test:watch
+```
+
+or without watch:
+
+```bash
+npm test
+```
+
+## Run while developing
+
+```bash
+npm run build:watch
 ```
 
 ## To release new version of this package

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@briangershon/npm-package-minimal",
-  "version": "4.1.0",
-  "type": "module",
   "description": "Example of publishing an NPM module to Github package repository.",
+  "version": "4.1.0",
   "module": "./dist/index.es.js",
   "main": "./dist/index.es.js",
   "exports": {
@@ -12,6 +11,7 @@
     }
   },
   "types": "./dist/index.d.ts",
+  "type": "module",
   "engines": {
     "node": ">=20.x"
   },

--- a/package.json
+++ b/package.json
@@ -4,20 +4,24 @@
   "type": "module",
   "description": "Example of publishing an NPM module to Github package repository.",
   "module": "./dist/index.es.js",
+  "main": "./dist/index.es.js",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js"
+      "import": "./dist/index.es.js",
+      "types": "./dist/index.d.ts"
     }
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "engines": {
     "node": ">=20.x"
   },
   "scripts": {
     "preversion": "npm run test && npm run lint",
     "postversion": "git push && git push --follow-tags",
-    "build": "tsc && vite build",
+    "build": "vite build",
+    "build:watch": "vite build --watch",
     "test": "vitest run",
+    "test:watch": "vitest",
     "coverage": "vitest --coverage",
     "format": "prettier --write src",
     "lint": "eslint src"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,15 @@
-import path, { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
-import { defineConfig } from "vite";
-import dts from "vite-plugin-dts";
+import path, { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
+  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
   build: {
     lib: {
-      entry: resolve(dirname(fileURLToPath(import.meta.url)), "src/index.ts"),
-      formats: ["es"],
+      entry: resolve(dirname(fileURLToPath(import.meta.url)), 'src/index.ts'),
+      formats: ['es'],
       fileName: (format) => `index.${format}.js`,
     },
   },


### PR DESCRIPTION
- fix "exports" and "types" bug in `package.json` so import works correctly when using package.
- add `build:watch` and `test:watch` scripts.
- pretty up `vite.config.ts`